### PR TITLE
Add settings panel for Revit API version

### DIFF
--- a/Flow.Launcher.Plugin.RevitAPISearch/Flow.Launcher.Plugin.RevitAPISearch.csproj
+++ b/Flow.Launcher.Plugin.RevitAPISearch/Flow.Launcher.Plugin.RevitAPISearch.csproj
@@ -10,6 +10,7 @@
     <PackageTags>flow-launcher flow-plugin</PackageTags>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Flow.Launcher.Plugin.RevitAPISearch/Main.cs
+++ b/Flow.Launcher.Plugin.RevitAPISearch/Main.cs
@@ -13,6 +13,11 @@ using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Plugin.RevitAPISearch
 {
+    /// <summary>
+    /// Represents a plugin for searching Revit API documentation via a web-based interface.
+    /// This class implements IAsyncPlugin and ISettingProvider, enabling asynchronous query processing
+    /// and the ability to manage user settings.
+    /// </summary>
     public class RevitAPISearch : IAsyncPlugin, ISettingProvider
     {
         private PluginInitContext _context;
@@ -22,6 +27,12 @@ namespace Flow.Launcher.Plugin.RevitAPISearch
         private HttpClient _httpClient;
         private Settings _settings;
         private string _settingsPath;
+
+        /// <summary>
+        /// Initializes the plugin asynchronously by setting up necessary context, loading settings, and preparing resources.
+        /// </summary>
+        /// <param name="context">The plugin initialization context providing metadata and API functionality.</param>
+        /// <returns>A task representing the asynchronous initialization operation.</returns>
         public Task InitAsync(PluginInitContext context)
         {
             _context = context;
@@ -37,7 +48,7 @@ namespace Flow.Launcher.Plugin.RevitAPISearch
                 }
                 catch (Exception ex)
                 {
-                    _context.API.LogError("RevitAPISearch", $"Failed to load settings from {_settingsPath}: {ex.Message}");
+                    _context.API.LogException(this.GetType().Name, $"Failed to load settings from {_settingsPath}: {ex.Message}", ex);
                     _settings = new Settings();
                 }
             }
@@ -50,6 +61,12 @@ namespace Flow.Launcher.Plugin.RevitAPISearch
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Executes an asynchronous query against the Revit API documentation and retrieves search results.
+        /// </summary>
+        /// <param name="query">The query object containing search terms and parameters to process the request.</param>
+        /// <param name="token">A cancellation token to signal the operation should be canceled.</param>
+        /// <returns>A task that represents the asynchronous query operation, returning a list of results.</returns>
         public async Task<List<Result>> QueryAsync(Query query, CancellationToken token)
         {
             string version = _settings.DefaultVersion;
@@ -120,6 +137,10 @@ namespace Flow.Launcher.Plugin.RevitAPISearch
             int total_results,
             bool truncated);
 
+        /// <summary>
+        /// Saves the current plugin settings to a persistent storage file.
+        /// This method serializes the settings object and writes it to the configured file path.
+        /// </summary>
         public void SaveSettings()
         {
             if (string.IsNullOrEmpty(_settingsPath))
@@ -136,6 +157,10 @@ namespace Flow.Launcher.Plugin.RevitAPISearch
             }
         }
 
+        /// <summary>
+        /// Creates and returns a settings panel for the plugin, facilitating user configuration of plugin settings.
+        /// </summary>
+        /// <returns>A Control representing the settings panel UI.</returns>
         public Control CreateSettingPanel()
         {
             return new SettingsControl(this, _settings);

--- a/Flow.Launcher.Plugin.RevitAPISearch/Main.cs
+++ b/Flow.Launcher.Plugin.RevitAPISearch/Main.cs
@@ -5,29 +5,53 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.IO;
+using System.Text.Json;
+using System.Windows.Controls;
+using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Plugin.RevitAPISearch
 {
-    public class RevitAPISearch : IAsyncPlugin
+    public class RevitAPISearch : IAsyncPlugin, ISettingProvider
     {
         private PluginInitContext _context;
 
         private Uri _baseUrl = new Uri("https://www.revitapidocs.com");
 
         private HttpClient _httpClient;
-
-        private readonly string defaultVersion = "2023";
+        private Settings _settings;
+        private string _settingsPath;
         public Task InitAsync(PluginInitContext context)
         {
             _context = context;
             _httpClient = new HttpClient();
+
+            _settingsPath = Path.Combine(_context.CurrentPluginMetadata.PluginDirectory, "settings.json");
+            if (File.Exists(_settingsPath))
+            {
+                try
+                {
+                    var json = File.ReadAllText(_settingsPath);
+                    _settings = JsonSerializer.Deserialize<Settings>(json) ?? new Settings();
+                }
+                catch
+                {
+                    _settings = new Settings();
+                }
+            }
+            else
+            {
+                _settings = new Settings();
+                SaveSettings();
+            }
+
             return Task.CompletedTask;
         }
 
         public async Task<List<Result>> QueryAsync(Query query, CancellationToken token)
         {
-            string version = defaultVersion;
+            string version = _settings.DefaultVersion;
             string apiString = query.FirstSearch;
             if (query.SearchTerms.Length > 1)
             {
@@ -88,12 +112,33 @@ namespace Flow.Launcher.Plugin.RevitAPISearch
 
 
         record RevitApiDocResult(
-            int max_result, 
-            string query, 
-            List<Dictionary<string, object>> results, 
+            int max_result,
+            string query,
+            List<Dictionary<string, object>> results,
             string target_year,
-            int total_results, 
+            int total_results,
             bool truncated);
+
+        public void SaveSettings()
+        {
+            if (string.IsNullOrEmpty(_settingsPath))
+                return;
+
+            try
+            {
+                var json = JsonSerializer.Serialize(_settings, new JsonSerializerOptions { WriteIndented = true });
+                File.WriteAllText(_settingsPath, json);
+            }
+            catch
+            {
+                // ignore persistence errors
+            }
+        }
+
+        public Control CreateSettingPanel()
+        {
+            return new SettingsControl(this, _settings);
+        }
 
     }
 }

--- a/Flow.Launcher.Plugin.RevitAPISearch/Main.cs
+++ b/Flow.Launcher.Plugin.RevitAPISearch/Main.cs
@@ -35,8 +35,9 @@ namespace Flow.Launcher.Plugin.RevitAPISearch
                     var json = File.ReadAllText(_settingsPath);
                     _settings = JsonSerializer.Deserialize<Settings>(json) ?? new Settings();
                 }
-                catch
+                catch (Exception ex)
                 {
+                    _context.API.LogError("RevitAPISearch", $"Failed to load settings from {_settingsPath}: {ex.Message}");
                     _settings = new Settings();
                 }
             }

--- a/Flow.Launcher.Plugin.RevitAPISearch/Settings.cs
+++ b/Flow.Launcher.Plugin.RevitAPISearch/Settings.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Flow.Launcher.Plugin.RevitAPISearch
+{
+    /// <summary>
+    /// Stores user configurable settings for the plugin.
+    /// </summary>
+    public class Settings
+    {
+        /// <summary>
+        /// The default Revit API version used for queries.
+        /// Only the numeric part is stored (e.g. "2023").
+        /// </summary>
+        public string DefaultVersion { get; set; } = "2023";
+    }
+}
+

--- a/Flow.Launcher.Plugin.RevitAPISearch/SettingsControl.xaml
+++ b/Flow.Launcher.Plugin.RevitAPISearch/SettingsControl.xaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="Flow.Launcher.Plugin.RevitAPISearch.SettingsControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Height="Auto" Width="Auto">
+    <Grid Margin="10">
+        <StackPanel>
+            <TextBlock Text="Default Version:" Margin="0,0,0,5"/>
+            <ComboBox x:Name="VersionComboBox" Width="100"
+                      SelectionChanged="VersionComboBox_SelectionChanged">
+                <ComboBoxItem Content="R2022" />
+                <ComboBoxItem Content="R2023" />
+                <ComboBoxItem Content="R2024" />
+                <ComboBoxItem Content="R2025" />
+                <ComboBoxItem Content="R2025.3" />
+                <ComboBoxItem Content="R2026" />
+            </ComboBox>
+        </StackPanel>
+    </Grid>
+</UserControl>
+

--- a/Flow.Launcher.Plugin.RevitAPISearch/SettingsControl.xaml.cs
+++ b/Flow.Launcher.Plugin.RevitAPISearch/SettingsControl.xaml.cs
@@ -1,0 +1,50 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Flow.Launcher.Plugin.RevitAPISearch
+{
+    /// <summary>
+    /// Interaction logic for SettingsControl.xaml
+    /// </summary>
+    public partial class SettingsControl : UserControl
+    {
+        private readonly Settings _settings;
+        private readonly RevitAPISearch _plugin;
+
+        public SettingsControl(RevitAPISearch plugin, Settings settings)
+        {
+            InitializeComponent();
+            _plugin = plugin;
+            _settings = settings;
+
+            VersionComboBox.SelectedIndex = VersionToIndex(_settings.DefaultVersion);
+        }
+
+        private static int VersionToIndex(string version)
+        {
+            switch ($"R{version}")
+            {
+                case "R2022": return 0;
+                case "R2023": return 1;
+                case "R2024": return 2;
+                case "R2025": return 3;
+                case "R2025.3": return 4;
+                case "R2026": return 5;
+                default: return 1;
+            }
+        }
+
+        private void VersionComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (VersionComboBox.SelectedItem is ComboBoxItem item)
+            {
+                var text = item.Content.ToString();
+                if (text.StartsWith("R"))
+                    text = text.Substring(1);
+                _settings.DefaultVersion = text;
+                _plugin.SaveSettings();
+            }
+        }
+    }
+}
+

--- a/Flow.Launcher.Plugin.RevitAPISearch/SettingsControl.xaml.cs
+++ b/Flow.Launcher.Plugin.RevitAPISearch/SettingsControl.xaml.cs
@@ -17,21 +17,22 @@ namespace Flow.Launcher.Plugin.RevitAPISearch
             _plugin = plugin;
             _settings = settings;
 
-            VersionComboBox.SelectedIndex = VersionToIndex(_settings.DefaultVersion);
+            VersionComboBox.SelectedIndex = VersionToIndex(_settings.DefaultVersion) >= 0 
+                ? VersionToIndex(_settings.DefaultVersion) 
+                : 0; // Default to the first item if the version is not found
         }
 
-        private static int VersionToIndex(string version)
+        private int VersionToIndex(string version)
         {
-            switch ($"R{version}")
+            string versionString = $"R{version}";
+            for (int i = 0; i < VersionComboBox.Items.Count; i++)
             {
-                case "R2022": return 0;
-                case "R2023": return 1;
-                case "R2024": return 2;
-                case "R2025": return 3;
-                case "R2025.3": return 4;
-                case "R2026": return 5;
-                default: return 1;
+                if (VersionComboBox.Items[i] is ComboBoxItem item && item.Content.ToString() == versionString)
+                {
+                    return i;
+                }
             }
+            return -1; // Return -1 if the version is not found
         }
 
         private void VersionComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
## Summary
- add `Settings` class to store default version
- add WPF `SettingsControl` with ComboBox
- load and save settings in `Main.cs`
- expose settings panel via `ISettingProvider`
- enable WPF in csproj

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b27c4c9ac8328a7c0381d086236bf